### PR TITLE
Remove the known issue of "15-25mins to create cluser"

### DIFF
--- a/source/kubernetes.rst
+++ b/source/kubernetes.rst
@@ -48,11 +48,3 @@ following command to assist our support team in helping you to resolve it.
 Known Issues
 ************
 
-**Cluster takes 15-25 minutes to deploy**
-
-
-* **Description:** Time to deploy a cluster is in the vicinity of 15-25
-  minutes.
-* **Status:** The cause of the problem is known and a release that reduces
-  deployment times is being planned.
-* **Workaround:** None.


### PR DESCRIPTION
Now we're migrating to Fedora CoreOS driver with Podman and hyperkube,
on POR and HLZ regions, a cluster creation now takes 6-10 mins.