### PR TITLE
add release note for template updates

### DIFF
--- a/source/release-notes.rst
+++ b/source/release-notes.rst
@@ -16,3 +16,4 @@ Table of Contents:
   release-notes/release_09_april_2020
   release-notes/release_25_may_2020
   release-notes/release_01_jul_2020
+  release-notes/release_10_sept_2020

--- a/source/release-notes/release_10_sept_2020.rst
+++ b/source/release-notes/release_10_sept_2020.rst
@@ -1,0 +1,22 @@
+#################
+10 September 2020
+#################
+
+Minor release to update the Kubernetes templates in the Container Infra
+service.
+
+************************
+Container Infra (Magnum)
+************************
+
+The existing templates have been updated to include the latest applicable
+version of Kubernetes.
+
+Please note the template names have changed to reflect this.
+
+* kubernetes-v1.16.14-dev-20200827
+* kubernetes-v1.16.14-prod-20200827
+* kubernetes-v1.18.8-dev-20200903
+* kubernetes-v1.18.8-prod-20200903
+* kubernetes-v1.17.11-dev-20200907
+* kubernetes-v1.17.11-prod-20200907


### PR DESCRIPTION
New versions of Kubernetes are now referenced by the templates.