### PR TITLE
Github has removed support for unauthenticated git protocol.

### DIFF
--- a/autobuild_requirements.txt
+++ b/autobuild_requirements.txt
@@ -1,5 +1,5 @@
 Sphinx>=1.8.2
--e git://github.com/catalyst-cloud/sphinx-catalystcloud-theme.git#egg=sphinx_catalystcloud_theme
+-e git+https://github.com/catalyst-cloud/sphinx-catalystcloud-theme.git#egg=sphinx_catalystcloud_theme
 doc8>=0.8.0
 sphinx-autobuild
 sphinx-tabs>=1.1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx>=1.8.2
--e git://github.com/catalyst-cloud/sphinx-catalystcloud-theme.git#egg=sphinx_catalystcloud_theme
+-e git+https://github.com/catalyst-cloud/sphinx-catalystcloud-theme.git#egg=sphinx_catalystcloud_theme
 doc8>=0.8.0
 sphinx-autobuild
 sphinx-tabs>=1.1.10


### PR DESCRIPTION
Github has removed support for unauthenticated git clone.

See:
https://github.blog/2021-09-01-improving-git-protocol-security-github/
