### PR TITLE
Add more hints about ratelimits

### DIFF
--- a/source/getting-started/access.rst
+++ b/source/getting-started/access.rst
@@ -91,9 +91,9 @@ Interface or Automation tools mentioned above) from anywhere on the Internet.
 
 We limit the rate at which you can make API requests, to ensure that the service
 is accessable to everyone equally. If you make too many requests in a short
-amount of time, we will send back an HTTP error message indicating you have
-exceeded the limits. You may need to configure your software using the API
-to retry in response to this error message.
+amount of time, we will send back an HTTP error message (code 429)
+indicating you have exceeded the limits. You may need to configure your 
+software using the API to retry in response to this error message.
 
 |
 

--- a/source/sdks-and-toolkits/apis.rst
+++ b/source/sdks-and-toolkits/apis.rst
@@ -9,6 +9,14 @@ implement on the Catalyst Cloud is first made available via an API, then the
 command line interface (CLI) and finally the dashboard. As a result, it often
 takes three to six months for a new feature or service to reach the dashboard.
 
+.. note::
+
+  The API is rate limited to prevent one customer from denying access to
+  other customers. When the rate limit is hit, the endpoint will return
+  a standard HTTP error response (code 429), and a header indicating how
+  much to back-off before retrying. Not all tools correctly implement
+  backing off in response to this message.
+
 *************
 API reference
 *************


### PR DESCRIPTION
Since the error code (429) wasn't mentioned, it was hard to find. Add it and also call out again we rate limit on the API page.