### PR TITLE
Update requirements to work with python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Sphinx>=1.8.2
+Sphinx>=4.2.0
 -e git+https://github.com/catalyst-cloud/sphinx-catalystcloud-theme.git#egg=sphinx_catalystcloud_theme
 doc8>=0.8.0
 sphinx-autobuild
-sphinx-tabs>=1.1.10
+sphinx-tabs>=2.0.0
 aafigure>=0.5


### PR DESCRIPTION
Sphinx has a bug which makes it not compatible with python 3.10, fixed in 4.2.0: https://github.com/sphinx-doc/sphinx/issues/9562

Consequently, Sphinx-tabs also needs to be updated as the add_javascript function got renamed to add_js_file (I picked version 2.0.0): https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_js_file