### PR TITLE
Add database username length limit

### DIFF
--- a/source/database/create-database.rst
+++ b/source/database/create-database.rst
@@ -63,8 +63,14 @@ First, lets determine what datastore types are available to us.
 .. Note::
 
   The openstack commands that are used in this tutorial should be the same
-  regardless of the datastore that you choose. The only difference will by
-  the datastore type and version you use to create your database.
+  regardless of the datastore that you choose. The only differences will be
+  the datastore type, datastore version version and the maximum length of
+  the initial username assigned during database instance creation.
+  
+  Maximum initial username length by datastore type:
+  
+  * MySQL: 16 characters
+  * Postgres: 63 characters.
 
 For this example we are going to use MySQL.
 


### PR DESCRIPTION
Be explicit about the initial username length for each datastore type in DBaaS.

MySQL 5.7.8+ supports 32 character usernames, but DBaaS deployment mechanism is designed to support all versions of MySQL. MySQL <5.7.8 only supported 16 characters. This should be updated when support of only  MySQL >=5.7.8 is made.