### PR TITLE
Fix links to GPU drivers/lic

### DIFF
--- a/source/compute/gpu-support.rst
+++ b/source/compute/gpu-support.rst
@@ -75,8 +75,14 @@ Then download and install the GRID driver package.
 .. code-block:: bash
 
     sudo apt install -y dkms
-    curl -O https://object-storage.nz-por-1.catalystcloud.io/v1/AUTH_483553c6e156487eaeefd63a5669151d/nvidia-guest-drivers/525/Linux/nvidia-linux-grid-525_525.60.13_amd64.deb
+    curl -O https://object-storage.nz-por-1.catalystcloud.io/v1/AUTH_483553c6e156487eaeefd63a5669151d/gpu-guest-drivers/nvidia/grid/15.0/linux/nvidia-linux-grid-525_525.60.13_amd64.deb
     sudo dpkg -i nvidia-linux-grid-525_525.60.13_amd64.deb
+
+.. note::
+
+    If you get a 404 response to this download, contact Catalyst Cloud
+    support as the driver versions may have been updated making this
+    documentation outdated.
 
 Next, you will need to install the client license for vGPU support.
 Download and save the license to ``/etc/nvidia/ClientConfigToken`` on
@@ -84,7 +90,7 @@ your virtual server, using the following steps:
 
 .. code-block:: bash
 
-    cd /etc/nvidia/ClientConfigToken && curl -O https://object-storage.nz-por-1.catalystcloud.io/v1/AUTH_483553c6e156487eaeefd63a5669151d/nvidia-guest-drivers/licenses/client_configuration_token_12-29-2022-15-20-23.tok
+    (cd /etc/nvidia/ClientConfigToken && curl -O https://object-storage.nz-por-1.catalystcloud.io/v1/AUTH_483553c6e156487eaeefd63a5669151d/gpu-guest-drivers/nvidia/grid/licenses/client_configuration_token_12-29-2022-15-20-23.tok)
 
 Edit the GRID driver configuration file ``/etc/nvidia/gridd.conf`` and
 ensure that ``FeatureType`` is set to ``1``. Then restart the NVIDIA
@@ -168,8 +174,14 @@ Then install the GRID driver package:
 
 .. code-block:: bash
 
-    curl -O https://object-storage.nz-por-1.catalystcloud.io/v1/AUTH_483553c6e156487eaeefd63a5669151d/nvidia-guest-drivers/525/Linux/NVIDIA-Linux-x86_64-525.60.13-grid.run
+    curl -O https://object-storage.nz-por-1.catalystcloud.io/v1/AUTH_483553c6e156487eaeefd63a5669151d/gpu-guest-drivers/nvidia/grid/15.0/linux/NVIDIA-Linux-x86_64-525.60.13-grid.run
     sudo sh NVIDIA-Linux-x86_64-525.60.13-grid.run -s -Z
+
+.. note::
+
+    If you get a 404 response to this download, contact Catalyst Cloud
+    support as the driver versions may have been updated making this
+    documentation outdated.
 
 This may produce errors or warnings related to missing X libraries and
 Vulkan ICD loader. These warnings can be safely ignored.
@@ -184,7 +196,7 @@ your virtual server, using the following steps:
 
 .. code-block:: bash
 
-    cd /etc/nvidia/ClientConfigToken && curl -O https://object-storage.nz-por-1.catalystcloud.io/v1/AUTH_483553c6e156487eaeefd63a5669151d/nvidia-guest-drivers/licenses/client_configuration_token_12-29-2022-15-20-23.tok
+    (cd /etc/nvidia/ClientConfigToken && curl -O https://object-storage.nz-por-1.catalystcloud.io/v1/AUTH_483553c6e156487eaeefd63a5669151d/gpu-guest-drivers/nvidia/grid/licenses/client_configuration_token_12-29-2022-15-20-23.tok)
 
 Edit the GRID driver configuration file ``/etc/nvidia/gridd.conf`` and
 ensure that ``FeatureType`` is set to ``1``. Then restart the NVIDIA


### PR DESCRIPTION
Some changes to the URLs for drivers and licenses for GPU VMs were missed.

Tested the links after making sure the docs build too this time!