### PR TITLE
Updated the limit on the warning about image uploads in the dashboard

### DIFF
--- a/source/images/uploading-image.rst
+++ b/source/images/uploading-image.rst
@@ -11,7 +11,7 @@ Via the command line tools
 **************************
 .. Warning::
 
-  If the Image you are trying to upload is larger than 500MB you **must** use
+  If the Image you are trying to upload is larger than 5GB you **must** use
   the OpenStack CLI to upload it to the cloud. This is due to a cap being
   placed on the dashboard.
 


### PR DESCRIPTION
It was 500MB but is actually 5GB now.