### PR TITLE
Fix two broken external links

### DIFF
--- a/source/tutorials/containers/deploying-a-hpc-slurm-cluster.rst
+++ b/source/tutorials/containers/deploying-a-hpc-slurm-cluster.rst
@@ -15,10 +15,8 @@ In this tutorial you will learn how to deploy a high performance computing
 .. _SLURM: https://slurm.schedmd.com/overview.html
 
 ElastiCluster is an open source tool to create and manage compute clusters on
-cloud infrastructures. The project was originally created by the `Grid
-Computing Competence Center`_ from the University of Zurich.
-
-.. _Grid Computing Competence Center: https://www.gc3.uzh.ch/
+cloud infrastructures. The project was originally created by the Grid
+Computing Competence Center from the University of Zurich.
 
 SLURM is a highly scalable cluster management and resource manager, used by
 many of the world's supercomputers and computer clusters (it is the workload

--- a/source/tutorials/other/region-failover-using-the-fastly-cdn.rst
+++ b/source/tutorials/other/region-failover-using-the-fastly-cdn.rst
@@ -413,7 +413,7 @@ you are happy that it is sane and validates. Please see the Fastly `working
 with services`_ documentation for more information about service versions and
 their activation.
 
-.. _working with services: https://docs.fastly.com/en/guides/working-with-services#understanding-services-and-versions
+.. _working with services: https://docs.fastly.com/en/guides/working-with-services#understanding-fastly-services-and-versions
 
 .. image:: ../_static/rf-clone.png
    :align: center


### PR DESCRIPTION
Remove the link to the gc3.uzh.ch (Grid Computing Competence Center) as it no longer resolves.
Updated link to anchor on the fastly tutorial.