### PR TITLE
Block storage faq header levels

### DIFF
--- a/source/block-storage/faq.rst
+++ b/source/block-storage/faq.rst
@@ -59,9 +59,9 @@ size of your volume?
 
 Well, as always, that depends.
 
-************
+============
 Boot volumes
-************
+============
 
 There are a number of different options, the best option for you to use will
 depend on your circumstances.
@@ -113,6 +113,7 @@ Finally, there is the old fashioned method that involves:
 * Attach the new volume and the original to another instance.
 * Perform a copy using tools like dd.
 
+================
 Non-boot volumes
 ================
 

--- a/source/tutorials/containers/deploying-a-hpc-slurm-cluster.rst
+++ b/source/tutorials/containers/deploying-a-hpc-slurm-cluster.rst
@@ -15,10 +15,8 @@ In this tutorial you will learn how to deploy a high performance computing
 .. _SLURM: https://slurm.schedmd.com/overview.html
 
 ElastiCluster is an open source tool to create and manage compute clusters on
-cloud infrastructures. The project was originally created by the `Grid
-Computing Competence Center`_ from the University of Zurich.
-
-.. _Grid Computing Competence Center: https://www.gc3.uzh.ch/
+cloud infrastructures. The project was originally created by the Grid
+Computing Competence Center from the University of Zurich.
 
 SLURM is a highly scalable cluster management and resource manager, used by
 many of the world's supercomputers and computer clusters (it is the workload

--- a/source/tutorials/other/region-failover-using-the-fastly-cdn.rst
+++ b/source/tutorials/other/region-failover-using-the-fastly-cdn.rst
@@ -413,7 +413,7 @@ you are happy that it is sane and validates. Please see the Fastly `working
 with services`_ documentation for more information about service versions and
 their activation.
 
-.. _working with services: https://docs.fastly.com/en/guides/working-with-services#understanding-services-and-versions
+.. _working with services: https://docs.fastly.com/en/guides/working-with-services#understanding-fastly-services-and-versions
 
 .. image:: ../_static/rf-clone.png
    :align: center


### PR DESCRIPTION
The header levels were incorrect on the FAQ section about resizing volumes: "Boot volumes" was at the same level as "How to grow a cinder volume?" when the former should have been a sub heading.