### PR TITLE
Remove reference the router HA.

### DIFF
--- a/source/network/network-bp.rst
+++ b/source/network/network-bp.rst
@@ -11,10 +11,7 @@ fails our monitoring systems will detect the failure and trigger the evacuate
 process that will ensure all affected virtual router instances are restarted on
 a healthy server. This process usually takes between 5 to 20 minutes.
 
-We are working on a new feature that launches two virtual routers on separate
-network nodes responding on the same IP address. Once this is complete the
-failover between routers will take milliseconds which will most likely not be
-noticed. Meanwhile customers requiring Higher availability are advised to
+Customers requiring high availability are advised to
 combine compute instances from multiple regions where possible.
 
 *************************************


### PR DESCRIPTION
Remove reference to router HA under the networking best practice as it is no longer something we are going to do.