### PR TITLE
Database instances need a connection to the internet to creae

### DIFF
--- a/source/database/create-database.rst
+++ b/source/database/create-database.rst
@@ -37,7 +37,9 @@ options, these include:
 * You will also need to source an OpenRC file in the correct region
 * It is also necessary to have an **existing network**,  which is attached to a
   router and has a working subnet, on the project that you wish to deploy the
-  database instance to.
+  database instance to. The network that you create the database instance in
+  **must** have access to the internet, as it is required to download the
+  support files to start the database.
 
 .. Warning::
 
@@ -306,6 +308,3 @@ is publicly available, but only from the specific cidr range: 202.37.199.1/24
   --nic net-id=908816f1-933c-4ff2-8595-xxxxxxxxxxxx \
   --is-public \
   --allowed-cidr 202.37.199.1/24 \
-
-
-

--- a/source/kubernetes/storage.rst
+++ b/source/kubernetes/storage.rst
@@ -63,11 +63,8 @@ Storage classes
 
 Catalyst Cloud provides pre-defined storage classes for all of the block
 storage tiers in each region. There are storage classes available for the
-default `standard storage tier`_ and for each of the
-`performance storage tiers`_.
-
-.. _`standard storage tier`: https://docs.catalystcloud.nz/block-storage/overview.html#the-standard-tier
-.. _`performance storage tiers`: https://docs.catalystcloud.nz/block-storage/overview.html#the-performance-tier
+default standard storage tier and for each of the
+performance storage tiers, see :doc:`/block-storage/volume-tiers`.
 
 The storage class names and their availability by region are as follows:
 


### PR DESCRIPTION
Clarify that the network in the customers project that the database instance is created in must have access to the internet.

Fix broken links that should have been internal and pointed to a section that have been rewritten
