### PR TITLE
Add backdated release notes for 1.29

### DIFF
--- a/source/backups.rst
+++ b/source/backups.rst
@@ -17,7 +17,7 @@ The main method of backing up your instances will be through the in built
 backup commands using Openstack. Alternatively, we also discuss ways that you
 can use `Duplicity`_ to create backups as well.
 
-.. _Duplicity: http://duplicity.nongnu.org/
+.. _Duplicity: https://duplicity.gitlab.io/
 
 The main distinction between the two is that the default Openstack backup
 creates new volume resource that holds a copy of your data from the point

--- a/source/backups/duplicity.rst
+++ b/source/backups/duplicity.rst
@@ -31,7 +31,7 @@ If you're using a major Linux distribution, you should be able to find a
 pre-compiled package in the repositories. If not, then a tar file is available
 at `Duplicity`_.
 
-.. _Duplicity: http://duplicity.nongnu.org/
+.. _Duplicity: https://duplicity.gitlab.io/
 
 .. code-block:: bash
 

--- a/source/kubernetes/clusters.rst
+++ b/source/kubernetes/clusters.rst
@@ -456,15 +456,10 @@ This section shows how to manually resize an existing cluster using the Catalyst
 
 .. note::
 
-  Catalyst Cloud Kubernetes Service does not support auto-scaling
-  of worker nodes in clusters running Kubernetes 1.28 and above at this time.
+   When using **cluster auto-scaling**, you instead set a minimum and maximum node
+   count, and the auto scaler will perform the resize actions within the provided bounds.
 
-.. TODO(callumdickinson): When auto-scaling is re-enabled, replace the note with the following:
-
-..   When using **cluster auto-scaling**, you instead set a minimum and maximum node
-..   count, and the auto scaler will perform the resize actions within the provided bounds.
-
-..   For more information, please refer to :ref:`auto-scaling`.
+   For more information, please refer to :ref:`auto-scaling`.
 
 Growing or shrinking a cluster
 ==============================

--- a/source/release-notes.rst
+++ b/source/release-notes.rst
@@ -35,3 +35,4 @@ Table of Contents:
   release-notes/release_2024-02-19.rst
   release-notes/release_2024-03-18.rst
   release-notes/release_2024-04-18.rst
+  release-notes/release_2024-05-27.rst

--- a/source/release-notes/release_2024-05-27.rst
+++ b/source/release-notes/release_2024-05-27.rst
@@ -1,0 +1,30 @@
+#############
+27 May 2024
+#############
+
+==================================
+Catalyst Cloud Kubernetes Service
+==================================
+
+We have released Cluster Templates for Kubernetes 1.29.
+
+The :ref:`supported-kubernetes-versions` section of our documentation has more
+information about this release and information on projected supported dates
+for this and other version releases.
+
+To get started using our CNCF Certified Kubernetes service, follow the
+:ref:`Kubernetes Quick-Start Guide<k8s-quickstart>`.
+
+===================
+Deprecation Notices
+===================
+
+------------------------
+Magnum Cluster Templates
+------------------------
+
+With the release of 1.29 for Catalyst Cloud Kubernetes Service, clusters
+built on 1.26 now transition to unsupported and 1.26 Cluster Templates
+are now hidden from the API.
+
+See :ref:`supported-kubernetes-versions` for more information.


### PR DESCRIPTION
Also:
* Fix links to duplicity
* Add autoscaler note back to clusters page.