### PR TITLE
Fix minor error using b (bits) and not B (bytes)

### DIFF
--- a/source/compute/faq.rst
+++ b/source/compute/faq.rst
@@ -29,7 +29,7 @@ shelving instances is due to the fact that you are no longer paying for the
 compute services that a running instance uses. Instead, you are now only
 paying the much cheaper cost of storing a snapshot of your image on disk.
 
-To illustrate this, let's say you had a simple 1 vCPU 1Gb RAM instance
+To illustrate this, let's say you had a simple 1 vCPU 1GB RAM instance
 with a 10GB disk running 24/7 for an entire month, which we will assume is
 730 hours as an average.
 


### PR DESCRIPTION
Pedantically, we did mean bytes in this sentence, not bits. I have also checked for other occurances of Gb instead of GB and there are no others I could see.