### PR TITLE
Change GPU flavours from "cores" to "vcpu", latter is more correct

### DIFF
--- a/source/compute/gpu-support.rst
+++ b/source/compute/gpu-support.rst
@@ -44,7 +44,7 @@ The current GPU flavours available are:
    :header-rows: 1
 
    * - Flavour
-     - CPU Cores
+     - vCPU
      - RAM
      - GPU Model
      - VRAM


### PR DESCRIPTION
This is a minor terminology change, we provide vCPU and describe what vCPU means in other docs.