### PR TITLE
Remove the mention of Retention and Lock for object storage

### DIFF
--- a/source/object-storage/object-storage-bp.rst
+++ b/source/object-storage/object-storage-bp.rst
@@ -48,11 +48,6 @@ There are a number of polices that you may wish to use when it comes to dealing
 with deleting data from your storage options. The following are some of the
 more common policies.
 
-- Retention policy: This policy dictates that an object cannot be deleted
-  until it reaches a certain age.
-- Object lock policy: The storage object is 'locked' and a specific user holds
-  the 'key' to the instance and only they can choose to delete data from
-  the instance or the instance itself.
 - Versioning policy: Whenever your object is changed a new version is created
   and the previous state of the storage object is saved. Should your newest
   version suffer some failure, you have the option to reload the previous


### PR DESCRIPTION
We've had mentions of object storage polices in our docs for years even though we don't support them.

Removing for now until we are able to release these features.